### PR TITLE
docs: update Github => GitHub

### DIFF
--- a/demo/frontend/src/Components/GitHubButton/GitHubButton.tsx
+++ b/demo/frontend/src/Components/GitHubButton/GitHubButton.tsx
@@ -4,7 +4,7 @@ import Container from './Container';
 
 const GitHubButton = () => (
   <Container href='https://github.com/maplibre/martin' target='_blank'>
-    <span>View on Github</span>
+    <span>View on GitHub</span>
     <img src={octocat} alt='octocat' />
   </Container>
 );


### PR DESCRIPTION
This is very minor — just uses the official style for writing out "GitHub" on the front page 😄 